### PR TITLE
Find the most recent conversion rate

### DIFF
--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -29,6 +29,7 @@ class Currency < ActiveRecord::Base
 
   def near_conversion(on)
     Conversion.where("book_on < ?", on).
+      order("book_on DESC").
       where(currency: self).first
   end
 end


### PR DESCRIPTION
When a conversion rate cannot be found, you want to find the one from the day before. Using the very first conversion rate is wrong.