### PR TITLE
Fix capital_gain calculation

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -59,11 +59,8 @@ class Event < ActiveRecord::Base
 
   def capital_gain
     if sell?
-      if pool[:size] > 0
-        cost = (quantity.to_f / pool[:size].to_f) * pool[:value]
-      else
-        cost = 0
-      end
+      previous_event = this_and_previous_events[-2]
+      cost = (quantity.to_f / previous_event.pool[:size]) * previous_event.pool[:value]
 
       (total - cost).round(2)
     end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -29,6 +29,25 @@ describe Event do
     # Cost ((350 / 600) x 2,400) DKK 1,400
     # Taxable gain               DKK   105
     e4.capital_gain.should == 105.0
+
+    # The following WAS NOT part of Lars' example
+
+    # Pool               250     DKK 1,000
+    e4.pool[:size].should == 250
+    e4.pool[:value].should == 1000
+
+    # On 1 Jan 2014 the remaining 250 shares are sold for DKK 2,500
+    e5 = Event.create(user: user, stock: fiat, action: :sell, quantity: 250, price: 10, executed_on: Date.parse('2014-1-1'), currency: currency)
+
+    # Proceeds                   DKK 2,500
+    # Cost ((250 / 250) x 1,000) DKK 1,000
+    # Taxable gain               DKK 1,500
+    e5.capital_gain.should == 1500
+
+    # And just to be sure:
+    e5.pool[:size].should == 0
+    e5.pool[:value].should == 0
+    e5.average_carrying.should == 0
   end
 
   it "passes Lars example 2" do


### PR DESCRIPTION
When emptying the stock pool, the initial cost of the sold stocks would be set to 0, causing all proceeds to be listed as taxable.

The fix is (I think) to look at the pool size and value *before* the current event – which is exactly what is described in the spec comments, e.g. [`Cost ((350 / 600) x 2,400) DKK 1,400`](https://github.com/libo/tesoro/blob/master/spec/event_spec.rb#L29).

Yo @libo 