### PR TITLE
Remove dep on sdoc and json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'responders', '~> 2.0'
 
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
-gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'bootstrap-sass'
 gem 'autoprefixer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.6)
     kgio (2.11.4)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -179,7 +178,6 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (4.3.0)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
@@ -213,9 +211,6 @@ GEM
       tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sdoc (0.4.2)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
     smarter_csv (1.2.9)
     spring (3.1.1)
     sprockets (3.7.2)
@@ -283,7 +278,6 @@ DEPENDENCIES
   responders (~> 2.0)
   rspec-rails
   sass-rails (~> 5.0.4)
-  sdoc (~> 0.4.0)
   smarter_csv
   spring
   sqlite3 (~> 1.3.6)


### PR DESCRIPTION
This gem was actually never used and I can't remember why I added.

It's quite noisy and add a dependencies with vuln `json v1.8.6` that we don't need
```
ruby/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
```

cc: @bquorning 