### PR TITLE
Simplify conversion_rate_to_default_currency

### DIFF
--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -23,12 +23,10 @@ class Currency < ApplicationRecord
     cache_key = "conversion_on/#{on}"
 
     Rails.cache.fetch(cache_key) do
-      conversion = Conversion.where(book_on: on).where(currency: self).first
+      conversion = near_conversion(on)
 
       if conversion.present?
         conversion.rate
-      elsif nc = near_conversion(on)
-        nc.rate
       else
         default_conversion_rate
       end
@@ -38,7 +36,7 @@ class Currency < ApplicationRecord
   private
 
   def near_conversion(on)
-    Conversion.where("book_on < ?", on).
+    Conversion.where("book_on <= ?", on).
       order("book_on DESC").
       where(currency: self).first
   end


### PR DESCRIPTION
Change `#near_conversion` to include the actual date (if exists); then we no longer need the query that tries to look up exact date - `#near_conversion` will always return that row, if it exists.