### PR TITLE
Gha config

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,10 @@
 name: CI RSpec Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Don't run twice when opening a pull request (once on push, once on PR open). Just run on all pull request events, and run when pushing to master (i.e. after merge).
