### PR TITLE
Optimise query to include currency and remove n+1

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -77,9 +77,10 @@ class Event < ApplicationRecord
 
   def this_and_previous_events
     # ordered so that buy are before sales.
-    Event.order(:executed_on, :action)
+    @this_and_previous_events ||= Event.order(:executed_on, :action)
       .where("executed_on <= ?", executed_on)
       .where(user_id: user_id)
       .where(stock_id: stock_id)
+      .includes(:currency)
   end
 end


### PR DESCRIPTION
This should remove some n+1 on the currency table.

4x faster

Before:
<img width="696" alt="Screenshot 2021-12-28 at 11 56 58" src="https://user-images.githubusercontent.com/37512/147559382-4a956af2-1197-40f4-a2ad-5eed69dce08a.png">

After:
<img width="699" alt="Screenshot 2021-12-28 at 11 56 37" src="https://user-images.githubusercontent.com/37512/147559386-f2d150a4-3f1a-4962-83ff-857773a71d20.png">


cc: @bquorning 