### PR TITLE
Allow seeing global stats by year

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,7 +18,7 @@ class EventsController < ApplicationController
 
     @events = current_user.events.events_for_year(@year).order(:executed_on, :action).includes(:stock, :currency).all
     @total_capital_gain = current_user.events.total_capital_gain(@year)
-    @stats = StatsCalculator.stats_for_user(current_user)
+    @stats = StatsCalculator.stats_for_user(current_user, @year)
 
     @taxes_unmarried = TaxCalculator::Unmarried.taxes_on(@total_capital_gain, @year)
     @taxes_married = TaxCalculator::Married.taxes_on(@total_capital_gain, @year)

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -98,9 +98,9 @@ $(function() {
   <thead>
     <tr>
       <th>Stock</th>
-      <th>Units Acquired</th>
-      <th>Units Sold</th>
-      <th>Units Left</th>
+      <th>Units Acquired<br>until end of <%= @year %></th>
+      <th>Units Sold<br>until end of <%= @year %></th>
+      <th>Units Left<br>by end of <%= @year %></th>
     </tr>
   </thead>
   <tbody>

--- a/lib/stats_calculator.rb
+++ b/lib/stats_calculator.rb
@@ -1,13 +1,15 @@
 class StatsCalculator
-  def self.stats_for_user(user)
+  def self.stats_for_user(user, year)
+    year_end = Date.new(year).end_of_year
+
     stock_ids(user).map do |id|
       stock = Stock.find_by_id(id)
 
       {
         name: stock.name,
         sym: stock.symbol,
-        quantity_acquired: user.events.where(stock_id: id).buy.sum(:quantity),
-        quantity_sold: user.events.where(stock_id: id).sell.sum(:quantity)
+        quantity_acquired: user.events.where(stock_id: id).where("executed_on <= ?", year_end).buy.sum(:quantity),
+        quantity_sold: user.events.where(stock_id: id).where("executed_on <= ?", year_end).sell.sum(:quantity)
       }
     end
   end

--- a/spec/stats_caculator_spec.rb
+++ b/spec/stats_caculator_spec.rb
@@ -15,7 +15,7 @@ describe StatsCalculator do
     Event.create(user: user, stock: fiat, action: :buy, quantity: 100, price: 2, executed_on: Date.parse('2010-1-1'), currency: currency)
     Event.create(user: user, stock: moderna, action: :buy, quantity: 100, price: 2, executed_on: Date.parse('2010-1-1'), currency: currency)
     Event.create(user: user, stock: fiat, action: :sell, quantity: 30, price: 2, executed_on: Date.parse('2010-1-1'), currency: currency)
-    Event.create(user: user, stock: moderna, action: :sell, quantity: 10, price: 2, executed_on: Date.parse('2010-1-1'), currency: currency)
+    Event.create(user: user, stock: moderna, action: :sell, quantity: 10, price: 2, executed_on: Date.parse('2011-1-1'), currency: currency)
 
     Event.create(user: other_user, stock: other, action: :buy, quantity: 100, price: 2, executed_on: Date.parse('2010-1-1'), currency: currency)
   end
@@ -28,13 +28,19 @@ describe StatsCalculator do
   end
 
   describe ".stats_for_user" do
-    it "returns the stats" do
-      expected = [
-        {:name=>"Fiat Chrysler Automobiles NV", :quantity_acquired=>100, :quantity_sold=>30, :sym=>"FCAU"},
-        {:name=>"Moderna", :quantity_acquired=>100, :quantity_sold=>10, :sym=>"MRNA"}
+    it "returns the acquired/sold stats per the end of given year" do
+      expect(StatsCalculator.stats_for_user(user, 2009)).to eq [
+        {quantity_acquired: 0, quantity_sold: 0, sym: "FCAU", name: "Fiat Chrysler Automobiles NV"},
+        {quantity_acquired: 0, quantity_sold: 0, sym: "MRNA", name: "Moderna"}
       ]
-
-      expect(StatsCalculator.stats_for_user(user)).to eq(expected)
+      expect(StatsCalculator.stats_for_user(user, 2010)).to eq [
+        {quantity_acquired: 100, quantity_sold: 30, sym: "FCAU", name: "Fiat Chrysler Automobiles NV"},
+        {quantity_acquired: 100, quantity_sold: 0, sym: "MRNA", name: "Moderna"}
+      ]
+      expect(StatsCalculator.stats_for_user(user, 2011)).to eq [
+        {quantity_acquired: 100, quantity_sold: 30, sym: "FCAU", name: "Fiat Chrysler Automobiles NV"},
+        {quantity_acquired: 100, quantity_sold: 10, sym: "MRNA", name: "Moderna"}
+      ]
     end
   end
 end


### PR DESCRIPTION
When validating/reporting taxes, it's useful to see e.g. how many stocks were "in the pool" by end of a given year. You can still see the global stats for "all of time" by visiting the events page for the current year.