### PR TITLE
add 2023 progressive tax rate

### DIFF
--- a/lib/tax_calculator.rb
+++ b/lib/tax_calculator.rb
@@ -1,6 +1,7 @@
 class TaxCalculator
   # From SKAT Satser https://www.skat.dk/SKAT.aspx?oId=2035568
   PROGRESSIVE_RATES = {
+    "2023" => 58900,
     "2022" => 57200,
     "2021" => 56500,
     "2020" => 55300,


### PR DESCRIPTION
Adds 2023 progressive rate, without this the application throws

```
ArgumentError - comparison of NilClass with 0 failed:
  lib/tax_calculator.rb:18:in `taxes_on'
  lib/tax_calculator.rb:32:in `taxes_on'
  app/controllers/events_controller.rb:23:in `index'
```

which breaks the application.